### PR TITLE
set is_sorted to true to allow resuming

### DIFF
--- a/tap_cloudwatch/client.py
+++ b/tap_cloudwatch/client.py
@@ -10,6 +10,18 @@ from tap_cloudwatch.cloudwatch_api import CloudwatchAPI
 class CloudWatchStream(Stream):
     """Stream class for CloudWatch streams."""
 
+    @property
+    def is_sorted(self) -> bool:
+        """Expect stream to be sorted.
+
+        When `True`, incremental streams will attempt to resume if unexpectedly
+        interrupted.
+
+        Returns:
+            `True` if stream is sorted. Defaults to `False`.
+        """
+        return True
+
     def get_records(self, context: Optional[dict]) -> Iterable[dict]:
         """Return a generator of record-type dictionary objects.
 

--- a/tap_cloudwatch/client.py
+++ b/tap_cloudwatch/client.py
@@ -17,8 +17,10 @@ class CloudWatchStream(Stream):
         When `True`, incremental streams will attempt to resume if unexpectedly
         interrupted.
 
-        Returns:
+        Returns
+        -------
             `True` if stream is sorted. Defaults to `False`.
+
         """
         return True
 


### PR DESCRIPTION
I had a backfill job running that I stopped purposefully and when I tried to restart it went back to using the start_date vs the replication bookmark. If I understand correctly this property will allow it to do what I expected. The stream queries using a sort by timestamp and I know that records are emitted in order so as far as I can tell its safe to enable this.

@edgarrmondragon any thoughts? Am I understanding this correctly?