### PR TITLE
fix: bugfix/missing logs

### DIFF
--- a/tap_cloudwatch/subquery.py
+++ b/tap_cloudwatch/subquery.py
@@ -48,11 +48,25 @@ class Subquery:
                 f" `{datetime.utcfromtimestamp(self.end_ts).isoformat()} UTC`"
             )
         )
-        response = self.client.get_query_results(queryId=self.query_id)
-        while response is None or response["status"] == "Running":
-            time.sleep(0.5)
+        response = None
+        retry = True
+        while response is None or response["status"] != "Complete":
             response = self.client.get_query_results(queryId=self.query_id)
-        if response.get("ResponseMetadata", {}).get("HTTPStatusCode") != 200:
+            status = response["status"]
+            if status in ("Failed", "Cancelled", "Timeout"):
+                # Retry the query
+                if retry:
+                    self.logger.info(f"Status: {status}. Retrying...")
+                    self.execute()
+                    retry = False
+                else:
+                    break
+            time.sleep(0.5)
+
+        if (
+            response.get("ResponseMetadata", {}).get("HTTPStatusCode") != 200
+            or response["status"] != "Complete"
+        ):
             raise Exception(f"Failed: {response}")
         result_size = response.get("statistics", {}).get("recordsMatched")
         results = response["results"]

--- a/tap_cloudwatch/subquery.py
+++ b/tap_cloudwatch/subquery.py
@@ -57,7 +57,8 @@ class Subquery:
             first = False
             response = self.client.get_query_results(queryId=self.query_id)
             status = response["status"]
-            if status in ("Failed", "Cancelled", "Timeout", "Scheduled", "Unknown"):
+            # TODO: handle Scheduled and Unknown. Need to wait before retrying.
+            if status in ("Failed", "Cancelled", "Timeout"):
                 # Retry the query
                 if retry:
                     self.logger.info(f"Status: {status}. Retrying...")

--- a/tap_cloudwatch/subquery.py
+++ b/tap_cloudwatch/subquery.py
@@ -50,10 +50,14 @@ class Subquery:
         )
         response = None
         retry = True
+        first = True
         while response is None or response["status"] != "Complete":
+            if not first:
+                time.sleep(0.5)
+            first = False
             response = self.client.get_query_results(queryId=self.query_id)
             status = response["status"]
-            if status in ("Failed", "Cancelled", "Timeout"):
+            if status in ("Failed", "Cancelled", "Timeout", "Scheduled", "Unknown"):
                 # Retry the query
                 if retry:
                     self.logger.info(f"Status: {status}. Retrying...")
@@ -61,7 +65,6 @@ class Subquery:
                     retry = False
                 else:
                     break
-            time.sleep(0.5)
 
         if (
             response.get("ResponseMetadata", {}).get("HTTPStatusCode") != 200

--- a/tap_cloudwatch/subquery.py
+++ b/tap_cloudwatch/subquery.py
@@ -57,7 +57,6 @@ class Subquery:
             first = False
             response = self.client.get_query_results(queryId=self.query_id)
             status = response["status"]
-            # TODO: handle Scheduled and Unknown. Need to wait before retrying.
             if status in ("Failed", "Cancelled", "Timeout"):
                 # Retry the query
                 if retry:
@@ -66,6 +65,8 @@ class Subquery:
                     retry = False
                 else:
                     break
+            if status in ("Scheduled", "Unknown"):
+                self.logger.info(f"Status: {status}, continuing to poll.")
 
         if (
             response.get("ResponseMetadata", {}).get("HTTPStatusCode") != 200

--- a/tap_cloudwatch/tests/test_cloudwatch_api.py
+++ b/tap_cloudwatch/tests/test_cloudwatch_api.py
@@ -21,7 +21,7 @@ from tap_cloudwatch.exception import InvalidQueryException
     ],
 )
 def test_split_batch_into_windows(start, end, batch, expected):
-    """Run standard tap tests from the SDK."""
+    """Test _split_batch_into_windows."""
     api = CloudwatchAPI(None)
     batches = api._split_batch_into_windows(start, end, batch)
     assert batches == expected

--- a/tap_cloudwatch/tests/test_cloudwatch_api.py
+++ b/tap_cloudwatch/tests/test_cloudwatch_api.py
@@ -18,6 +18,16 @@ from tap_cloudwatch.exception import InvalidQueryException
             3600,
             [(1672272000, 1672275600), (1672275601, 1672279200)],
         ],
+        [
+            1672272000,
+            1672282800,
+            3600,
+            [
+                (1672272000, 1672275600),
+                (1672275601, 1672279200),
+                (1672279201, 1672282800),
+            ],
+        ],
     ],
 )
 def test_split_batch_into_windows(start, end, batch, expected):

--- a/tap_cloudwatch/tests/test_core.py
+++ b/tap_cloudwatch/tests/test_core.py
@@ -41,7 +41,7 @@ def test_standard_tap_tests(patch_client):
     stubber.add_response(
         "get_query_results",
         {
-            "status": "abc",
+            "status": "Complete",
             "results": [
                 [
                     {"field": "@timestamp", "value": "2022-01-01"},

--- a/tap_cloudwatch/tests/test_query.py
+++ b/tap_cloudwatch/tests/test_query.py
@@ -3,6 +3,7 @@
 import boto3
 from botocore.stub import Stubber
 from freezegun import freeze_time
+from unittest.mock import patch
 
 from tap_cloudwatch.subquery import Subquery
 
@@ -18,7 +19,7 @@ def test_subquery():
     in_query = "fields @timestamp, @message"
 
     response = {
-        "status": "abc",
+        "status": "Complete",
         "results": [
             [
                 {"field": "@timestamp", "value": "2022-01-01"},
@@ -41,6 +42,11 @@ def test_subquery():
     )
     stubber.add_response(
         "get_query_results",
+        {"status": "Running"},
+        {"queryId": "123"},
+    )
+    stubber.add_response(
+        "get_query_results",
         response,
         {"queryId": "123"},
     )
@@ -51,3 +57,69 @@ def test_subquery():
     output = query_obj.get_results()
 
     assert response["results"] == output
+
+@patch.object(Subquery, "_handle_limit_exceeded", return_value=["foo"])
+def test_subquery_limit_exceeded(patch_limit):
+    """Run subquery test."""
+    client = boto3.client("logs", region_name="us-east-1")
+    stubber = Stubber(client)
+    query_start = 1672272000
+    query_end = 1672275600
+    log_group = "my_log_group_name"
+    in_query = "fields @timestamp, @message"
+
+    response = {
+        "status": "Complete",
+        "results": [
+            [
+                {"field": "@timestamp", "value": "2022-01-01"},
+                {"field": "@message", "value": "abc"},
+            ]
+        ],
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+        "statistics": {"recordsMatched": 10001},
+    }
+    stubber.add_response(
+        "get_query_results",
+        response,
+        {"queryId": "123"},
+    )
+    stubber.activate()
+
+    query_obj = Subquery(client, query_start, query_end, log_group, in_query)
+    query_obj.query_id = "123"
+    output = query_obj.get_results()
+
+    patch_limit.assert_called_with(response)
+    results = response["results"]
+    results += ["foo"]
+    assert results == output
+
+@patch.object(Subquery, "execute")
+@patch.object(Subquery, "get_results")
+def test__handle_limit_exceeded(patch_result, execute):
+    """Run subquery test."""
+    response = {
+        "status": "Complete",
+        "results": [
+            [
+                {"field": "@timestamp", "value": "2022-01-01"},
+                {"field": "@message", "value": "abc"},
+            ],
+            [
+                {"field": "@timestamp", "value": "2023-01-01"},
+                {"field": "@message", "value": "def"},
+            ]
+        ],
+        "ResponseMetadata": {"HTTPStatusCode": 200},
+        "statistics": {"recordsMatched": 10001},
+    }
+
+    query_obj = Subquery("", "", "", "", "")
+    query_obj.query_id = "123"
+    output = query_obj._handle_limit_exceeded(response)
+
+    patch_result.assert_called()
+    execute.assert_called()
+    
+    assert query_obj.start_ts == 1672531200

--- a/tap_cloudwatch/tests/test_query.py
+++ b/tap_cloudwatch/tests/test_query.py
@@ -189,7 +189,7 @@ def test_handle_limit_exceeded(patch_result, execute):
 
     query_obj = Subquery("", "", "", "", "")
     query_obj.query_id = "123"
-    output = query_obj._handle_limit_exceeded(response)
+    query_obj._handle_limit_exceeded(response)
 
     patch_result.assert_called()
     execute.assert_called()

--- a/tap_cloudwatch/tests/test_query.py
+++ b/tap_cloudwatch/tests/test_query.py
@@ -58,6 +58,7 @@ def test_subquery():
 
     assert response["results"] == output
 
+
 @freeze_time("2022-12-30")
 def test_subquery_incomplete():
     """Run subquery test."""
@@ -95,8 +96,8 @@ def test_subquery_incomplete():
         {
             "status": "Scheduled",
             "ResponseMetadata": {"HTTPStatusCode": 200},
-            "statistics": {'recordsMatched': 0.0},
-            "results": []
+            "statistics": {"recordsMatched": 0.0},
+            "results": [],
         },
         {"queryId": "123"},
     )
@@ -112,6 +113,7 @@ def test_subquery_incomplete():
     output = query_obj.get_results()
 
     assert response["results"] == output
+
 
 @patch.object(Subquery, "_handle_limit_exceeded", return_value=["foo"])
 def test_subquery_limit_exceeded(patch_limit):
@@ -150,6 +152,7 @@ def test_subquery_limit_exceeded(patch_limit):
     results += ["foo"]
     assert results == output
 
+
 @patch.object(Subquery, "execute")
 @patch.object(Subquery, "get_results")
 def test_handle_limit_exceeded(patch_result, execute):
@@ -164,7 +167,7 @@ def test_handle_limit_exceeded(patch_result, execute):
             [
                 {"field": "@timestamp", "value": "2023-01-01"},
                 {"field": "@message", "value": "def"},
-            ]
+            ],
         ],
         "ResponseMetadata": {"HTTPStatusCode": 200},
         "statistics": {"recordsMatched": 10001},
@@ -176,5 +179,5 @@ def test_handle_limit_exceeded(patch_result, execute):
 
     patch_result.assert_called()
     execute.assert_called()
-    
+
     assert query_obj.start_ts == 1672531200

--- a/tap_cloudwatch/tests/test_query.py
+++ b/tap_cloudwatch/tests/test_query.py
@@ -1,13 +1,14 @@
 """Tests subquery module."""
 
-import boto3
-from botocore.stub import Stubber
-from freezegun import freeze_time
+from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
-from tap_cloudwatch.subquery import Subquery
+import boto3
 import pytest
-from contextlib import nullcontext as does_not_raise
+from botocore.stub import Stubber
+from freezegun import freeze_time
+
+from tap_cloudwatch.subquery import Subquery
 
 
 @freeze_time("2022-12-30")

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands =
     poetry run coverage run -m pytest --capture=no
     poetry run coverage html -d tap_cloudwatch/tests/codecoverage
     poetry run black --check tap_cloudwatch/
+    poetry run isort --check tap_cloudwatch
     poetry run flake8 tap_cloudwatch
     poetry run pydocstyle tap_cloudwatch
     poetry run mypy tap_cloudwatch --exclude='tap_cloudwatch/tests'


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/tap-cloudwatch/issues/15

It looks like the bug was related to not handling of failure statuses properly. It seems that we get a valid 200 status response with a status of "Failed", "Cancelled", "Timeout" that we werent asserting. All other attributes were available so no error was thrown but it showed 0 records found and continued. This was happening for us periodically on recursive subbatches that were attempting to get more records then breaking from the recursion because they returned 0 records. I think it affects the subbatches because they are executed and immediately requested so its possible theres no valid status yet. Moving forward we either retry then error or we log unknown/scheduled for awareness and continue.
